### PR TITLE
Handle null errorStream case

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'prabin.timsina'
-version '1.0'
+version '1.0.1'
 
 def remoteRobotVersion = "0.11.16"
 
@@ -58,8 +58,4 @@ downloadRobotServerPlugin {
 
 test {
     useJUnitPlatform()
-}
-
-patchPluginXml {
-    changeNotes = """First release of the API Bank plugin"""
 }

--- a/src/main/kotlin/api/bank/models/ResponseDetail.kt
+++ b/src/main/kotlin/api/bank/models/ResponseDetail.kt
@@ -4,7 +4,7 @@ package api.bank.models
  * Represents portion of useful data from a response
  */
 data class ResponseDetail(
-    val body: String,
+    val body: String?,
     val code: Int,
     val message: String,
 )

--- a/src/main/kotlin/api/bank/multitab/EditorTab.kt
+++ b/src/main/kotlin/api/bank/multitab/EditorTab.kt
@@ -5,6 +5,7 @@ import api.bank.models.Constants
 import api.bank.models.Constants.COLOR_GREEN
 import api.bank.models.Constants.COLOR_RED
 import api.bank.models.RequestDetail
+import api.bank.models.ResponseDetail
 import api.bank.repository.CoreRepository
 import api.bank.table.TableCellListener
 import api.bank.table.TableColumnAdjuster
@@ -13,6 +14,7 @@ import api.bank.utils.dispatcher.DispatcherProvider
 import api.bank.utils.listener.SimpleDocumentListener
 import com.google.gson.Gson
 import com.google.gson.JsonParser
+import com.google.gson.JsonSyntaxException
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.JBSplitter
@@ -399,7 +401,7 @@ class EditorTab(
                 variables = getVariables(),
             )
 
-            jOutput.text = gson.toJson(JsonParser.parseString(output.body))
+            setOutputBody(output)
 
             val color = when (output.code < 400) {
                 true -> COLOR_GREEN
@@ -407,6 +409,20 @@ class EditorTab(
             }
 
             jOutputLabel.text = "<html><font color='$color'>${output.code}</font> ${output.message}</html>"
+        }
+    }
+
+    private fun setOutputBody(output: ResponseDetail) {
+        val outputBody = output.body
+
+        jOutput.text = if (outputBody.isNullOrBlank()) {
+            outputBody
+        } else {
+            try {
+                gson.toJson(JsonParser.parseString(outputBody))
+            } catch (e: JsonSyntaxException) {
+                outputBody
+            }
         }
     }
 }

--- a/src/main/kotlin/api/bank/repository/DefaultCoreRepository.kt
+++ b/src/main/kotlin/api/bank/repository/DefaultCoreRepository.kt
@@ -17,7 +17,7 @@ class DefaultCoreRepository constructor(
 
     override suspend fun executeRequest(
         requestDetail: RequestDetail,
-        variables: List<Array<String>>
+        variables: List<Array<String>>,
     ): ResponseDetail {
         return withContext(dispatcherProvider.io) {
             val updatedDetail = substituteVariables(requestDetail, variables)
@@ -34,12 +34,16 @@ class DefaultCoreRepository constructor(
 
                 when {
                     urlConnection.responseCode >= 400 -> {
-                        val body = urlConnection.errorStream.bufferedReader().use { reader -> reader.readText() }
+                        val body = urlConnection.errorStream?.let { inputStream ->
+                            inputStream.bufferedReader().use { reader -> reader.readText() }
+                        }
                         ResponseDetail(body, urlConnection.responseCode, urlConnection.responseMessage)
                     }
 
                     else -> {
-                        val body = urlConnection.inputStream.bufferedReader().use { reader -> reader.readText() }
+                        val body = urlConnection.inputStream?.let { inputStream ->
+                            inputStream.bufferedReader().use { reader -> reader.readText() }
+                        }
                         ResponseDetail(body, urlConnection.responseCode, urlConnection.responseMessage)
                     }
                 }
@@ -51,7 +55,7 @@ class DefaultCoreRepository constructor(
 
     private fun substituteVariables(
         requestDetail: RequestDetail,
-        variableItems: List<Array<String>>
+        variableItems: List<Array<String>>,
     ): RequestDetail {
         val variables = variableItems.toMutableList()
 


### PR DESCRIPTION
### Description
1. `errorStream` and `inputStream` can be null in response. So, handle those gracefully.
2. Support displaying of non-json response body

### Links
[Bug report](https://github.com/prabint/api-bank/issues/6)
